### PR TITLE
fix: body should be scroll when close modal

### DIFF
--- a/packages/vue/src/composables/plugin.ts
+++ b/packages/vue/src/composables/plugin.ts
@@ -151,7 +151,7 @@ export function useRainbowKitPlugin() {
         }
       },
       unmounted: (el, _) => {
-        disableBodyScroll(el);
+        enableBodyScroll(el);
       }
     });
   }
@@ -198,7 +198,7 @@ export function useRainbowKitPlugin() {
         ...wagmiParameters
       });
       app.use(WagmiPlugin, { config });
-      app.use(VueQueryPlugin,{});
+      app.use(VueQueryPlugin, {});
     }
   }
 

--- a/packages/vue/src/composables/wallet.connect.ts
+++ b/packages/vue/src/composables/wallet.connect.ts
@@ -17,7 +17,6 @@ export function configureWalletConnectStoreContext(){
         wallets,
       })?.createWalletConnectModalConnector;
     
-      console.log(connector);
     ///preload wallet connect   
     if(connector){
         store.createWalletConnectModalConnector({ createConnector:connector, config });


### PR DESCRIPTION
When I close the pop-up window, I notice that the page has become unscrollable.

When the component is unmounted, scrolling of the body element should be allowed.

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/e6741937-bd6b-4c6a-b29f-39e461874a33" />

